### PR TITLE
Updated image uploading logic

### DIFF
--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -1,5 +1,6 @@
 import express from "express";
 import Session from "../models/session.js";
+import ImageUploadService from "../services/ImageUploadService.js";
 
 const router = express.Router();
 
@@ -141,6 +142,8 @@ router.patch("/:id/add-player", async (req, res) => {
  *
  * URL parameters:
  * - id (string): The ID of the session to update.
+ * - folder (string): The name of the folder in which to store the uploaded file, one of "drawings/quadrants", "drawings/complete", or "profilePics"
+ * - quadrantNumber (string): The quadrant number of the drawing, if applicable. One of 1, 2, 3, or 4.
  *
  * Request body parameters:
  * - A multipart/form-data payload with a key of "img" and the value being the file to be uploaded.
@@ -151,7 +154,7 @@ router.patch("/:id/add-player", async (req, res) => {
 router.patch("/:id/upload-drawing", async (req, res) => {
   try {
     const imageUploadService = new ImageUploadService();
-    const publicUrl = await imageUploadService.uploadFile(req, "drawings");
+    const publicUrl = await imageUploadService.uploadFile(req);
 
     const result = await Session.updateOne(
       { _id: req.params.id },

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -142,11 +142,12 @@ router.patch("/:id/add-player", async (req, res) => {
  *
  * URL parameters:
  * - id (string): The ID of the session to update.
- * - folder (string): The name of the folder in which to store the uploaded file, one of "drawings/quadrants", "drawings/complete", or "profilePics"
- * - quadrantNumber (string): The quadrant number of the drawing, if applicable. One of 1, 2, 3, or 4.
  *
  * Request body parameters:
- * - A multipart/form-data payload with a key of "img" and the value being the file to be uploaded.
+ * - A multipart/form-data payload with:
+ * - key: "img", value: the file to be uploaded
+ * - key: "folder", value: the name of the folder in which to store the uploaded file, one of "drawings/quadrants", "drawings/complete", or "profilePics"
+ * - key: "quadrantNumber", value: the quadrant number of the drawing, if applicable. One of 1, 2, 3, or 4.
  *
  * Returns:
  * - A JSON object with a single property, publicUrl, containing the public URL of the uploaded file.

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -146,7 +146,7 @@ router.patch("/:id/add-player", async (req, res) => {
  * Request body parameters:
  * - A multipart/form-data payload with:
  * - key: "img", value: the file to be uploaded
- * - key: "folder", value: the name of the folder in which to store the uploaded file, one of "drawings/quadrants", "drawings/complete", or "profilePics"
+ * - key: "folder", value: the name of the folder in which to store the uploaded file, one of "drawings/quadrants", "drawings/complete"
  * - key: "quadrantNumber", value: the quadrant number of the drawing, if applicable. One of 1, 2, 3, or 4.
  *
  * Returns:

--- a/server/routes/sessions.js
+++ b/server/routes/sessions.js
@@ -146,8 +146,8 @@ router.patch("/:id/add-player", async (req, res) => {
  * Request body parameters:
  * - A multipart/form-data payload with:
  * - key: "img", value: the file to be uploaded
- * - key: "folder", value: the name of the folder in which to store the uploaded file, one of "drawings/quadrants", "drawings/complete"
- * - key: "quadrantNumber", value: the quadrant number of the drawing, if applicable. One of 1, 2, 3, or 4.
+ * - key: "folder", value: the name of the folder in which to store the uploaded file, either "drawings/quadrants", "drawings/complete"
+ * - key: "quadrantNumber", value: the quadrant number of the drawing, if applicable. One of 0, 1, 2, or 3.
  *
  * Returns:
  * - A JSON object with a single property, publicUrl, containing the public URL of the uploaded file.

--- a/server/services/ImageUploadService.js
+++ b/server/services/ImageUploadService.js
@@ -23,7 +23,7 @@ class ImageUploadService {
     this.bucket = storage.bucket("sketchconnect-images");
   }
 
-  async uploadFile(req, folder) {
+  async uploadFile(req) {
     return new Promise((resolve, reject) => {
       this.multer.single("img")(req, {}, async (error) => {
         if (error) {
@@ -31,9 +31,19 @@ class ImageUploadService {
           reject(error);
         } else {
           try {
-            const timestamp = this.getFormattedTimestamp();
             const extension = path.extname(req.file.originalname);
-            const fileName = `${timestamp}` + extension;
+            const quadrantNumber = req.body.quadrantNumber;
+            let folder = "";
+            let fileName = "";
+
+            if (req.body.folder === "drawings/quadrants") {
+              folder = `${req.body.folder}/${req.params.id}`;
+              fileName = `${quadrantNumber}` + extension;
+            } else {
+              folder = req.body.folder;
+              fileName = `${req.params.id}` + extension;
+            }
+
             const blob = this.bucket.file(`${folder}/${fileName}`);
             const blobStream = blob.createWriteStream();
 
@@ -53,11 +63,6 @@ class ImageUploadService {
         }
       });
     });
-  }
-
-  getFormattedTimestamp() {
-    const now = new Date();
-    return format(now, "MM-dd-yyyy-HH:mm:ss:SSS");
   }
 }
 


### PR DESCRIPTION
There are now 2 options for sessions image uploading (`/session/:id/upload-drawing`):

1. Uploading quadrant drawings, in the form-data payload, send the following:
	- img: the file to be uploaded
	- folder: "drawings/quadrants"
	- quadrantNumber: the number of the quadrant you are uploading
	result: the image(s) will be uploaded to a folder called `drawings/quadrants/{session id}` and it'll be called `{order}.png/jpg`

2. Uploading completed drawings, in the form-data payload, send the following:
	- img: the file to be uploaded
	- folder: "drawings/completed"
	result: the image(s) will be uploaded to a folder called `drawings/complete` and it'll be called `{session id}.png/jpg`